### PR TITLE
Allow python to work with versions before Python 3.6

### DIFF
--- a/src/python/pythonHelper.ts
+++ b/src/python/pythonHelper.ts
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import { PythonShell } from "python-shell";
 import * as vscode from "vscode";
 
 import Helper from "../helpers/helper";
@@ -9,10 +10,23 @@ import PythonConfiguration from "./pythonConfiguration";
 export default class PythonHelper {
   static parse(code: string, fsPath: string, context: vscode.ExtensionContext): ParameterPosition[][] {
     // const command = `${PythonConfiguration.executablePath()} ${context.extensionPath}/src/python/helpers/main.py ${fsPath}`; // Development
-    const command = `${PythonConfiguration.executablePath()} ${context.extensionPath}/out/src/python/helpers/main.py ${fsPath}`; // Production
+    const pythonPath = PythonHelper.getPythonPath();
+    const command = `${pythonPath} ${context.extensionPath}/out/src/python/helpers/main.py ${fsPath}`; // Production
     const output = execSync(command).toString();
 
     return this.getParametersFromOutput(code, output);
+  }
+
+  public static getPythonPath(resource: vscode.Uri = null): string {
+    // adapted from vscode-restructuredtext/vscode-restructuredtext#224
+    const extension = vscode.extensions.getExtension("ms-python.python")
+    if (!extension) {
+      const pythonPath = `${PythonConfiguration.executablePath()}`
+      return pythonPath ? pythonPath : PythonShell.defaultPythonPath
+    }
+    const pythonPath = extension.exports.settings.getExecutionDetails(resource).execCommand
+    return pythonPath[0]; // might be more elements if conda, but we are not bothering to support that yet
+
   }
 
   static getParametersFromOutput(code: string, output: string): ParameterPosition[][] | undefined {


### PR DESCRIPTION
- Allow python to work with versions before Python 3.6
- Allow user to manually change Python path (pervious version on the master branch doesn't work)