### PR TITLE
Bugfix and features for python

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "./out/src/extension.js",
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.66.0"
   },
   "categories": [
     "Other"
@@ -156,7 +156,7 @@
           }
         }
       }
-    ]
+		]    
   },
   "scripts": {
     "compile": "rimraf out && tsc -p ./",

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -21,10 +21,11 @@ export default class Helper {
    * 
    * @param parameterName - The parameter name to format.
    * @param hintBeforeParameter - The position of the parameter.
+   * @param separator - Separator to add between hint and parameter if hint is before parameter. Default is `:`.
    * @returns The parameter formatted for display.
    */
-  static formatParameterName(parameterName: string, hintBeforeParameter: boolean): string {
-    if (hintBeforeParameter) parameterName += ":";
+  static formatParameterName(parameterName: string, hintBeforeParameter: boolean, separator: string = ":"): string {
+    if (hintBeforeParameter) parameterName += separator;
 
     return parameterName;
   }

--- a/src/python/pythonDriver.ts
+++ b/src/python/pythonDriver.ts
@@ -29,7 +29,7 @@ export default class PythonDriver {
           for (let index = 0; index < languageParameters.length; index++) {
             const parameter = languageParameters[index];
             if (parameters[index] === undefined || parameters[index].name === undefined) continue;
-            const parameterName = Helper.formatParameterName(parameters[index].name, PythonConfiguration.hintBeforeParameter());
+            const parameterName = Helper.formatParameterName(parameters[index].name, PythonConfiguration.hintBeforeParameter(), "=");
             const parameterDefinition = parameters[index].definition;
 
             if (!parameterName) continue;

--- a/src/python/pythonDriver.ts
+++ b/src/python/pythonDriver.ts
@@ -41,6 +41,9 @@ export default class PythonDriver {
               const inlayHintPart = new vscode.InlayHintLabelPart(parameterName);
               inlayHint = new vscode.InlayHint(position, [inlayHintPart], vscode.InlayHintKind.Parameter);
               inlayHint.tooltip = new vscode.MarkdownString(parameterDefinition);
+              if (index == languageParameters.length - 1) {
+                inlayHint.textEdits = [vscode.TextEdit.insert(position, parameterName)]
+              }
               inlayHint.paddingRight = true;
             } else {
               const position = new vscode.Position(parameter.end.line, parameter.end.character);

--- a/src/python/pythonHelper.ts
+++ b/src/python/pythonHelper.ts
@@ -143,28 +143,23 @@ export default class PythonHelper {
       )
     );
 
-    const pythonParameterNameRegex = /^[a-zA-Z_]([0-9a-zA-Z_]+)?/g;
     if (description && description.length > 0) {
       try {
-        const regEx = /.*?\((?:class|function|method)\).*?\((.*?)\)/gs;
+        const regEx = /.*?(?:class \w+|\(function\) def \w+|\(method\) def \w+)\((.*?)\)/s;
         definitions = Helper.getFunctionDefinition(<vscode.MarkdownString[]>description[0].contents)?.match(regEx);
 
-        if (!definitions || !definitions[0]) {
+        if (!definitions || !definitions[1]) {
           return Promise.reject();
         }
 
-        definition = definitions[0];
+        definition = definitions[1];
       } catch (error) {
         console.error(error);
       }
     }
 
-    definition = definition.replace(/\(class\)/, "");
-    definition = definition.replace(/\(function\)/, "");
-    definition = definition.replace(/\(method\)/, "");
-
+    const pythonParameterNameRegex = /^[a-zA-Z_]([0-9a-zA-Z_]+)?/g;
     const parameters: string[] = definition
-      .substring(definition.indexOf("(") + 1, definition.indexOf(")"))
       // eslint-disable-next-line no-useless-escape
       .split(/,/)
       .map(parameter => parameter.trim())

--- a/vscode.d.ts
+++ b/vscode.d.ts
@@ -2065,6 +2065,18 @@ declare module 'vscode' {
 		readonly language?: string;
 
 		/**
+		 * The {@link NotebookDocument.notebookType type} of a notebook, like `jupyter-notebook`. This allows
+		 * to narrow down on the type of a notebook that a {@link NotebookCell.document cell document} belongs to.
+		 *
+		 * *Note* that setting the `notebookType`-property changes how `scheme` and `pattern` are interpreted. When set
+		 * they are evaluated against the {@link NotebookDocument.uri notebook uri}, not the document uri.
+		 *
+		 * @example <caption>Match python document inside jupyter notebook that aren't stored yet (`untitled`)</caption>
+		 * { language: 'python', notebookType: 'jupyter-notebook', scheme: 'untitled' }
+		 */
+		readonly notebookType?: string;
+
+		/**
 		 * A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
 		 */
 		readonly scheme?: string;
@@ -2659,6 +2671,27 @@ declare module 'vscode' {
 		 * for a list of all supported tags and attributes.
 		 */
 		supportHtml?: boolean;
+
+		/**
+		 * Uri that relative paths are resolved relative to.
+		 *
+		 * If the `baseUri` ends with `/`, it is considered a directory and relative paths in the markdown are resolved relative to that directory:
+		 *
+		 * ```ts
+		 * const md = new vscode.MarkdownString(`[link](./file.js)`);
+		 * md.baseUri = vscode.Uri.file('/path/to/dir/');
+		 * // Here 'link' in the rendered markdown resolves to '/path/to/dir/file.js'
+		 * ```
+		 *
+		 * If the `baseUri` is a file, relative paths in the markdown are resolved relative to the parent dir of that file:
+		 *
+		 * ```ts
+		 * const md = new vscode.MarkdownString(`[link](./file.js)`);
+		 * md.baseUri = vscode.Uri.file('/path/to/otherFile.js');
+		 * // Here 'link' in the rendered markdown resolves to '/path/to/file.js'
+		 * ```
+		 */
+		baseUri?: Uri;
 
 		/**
 		 * Creates a new markdown string with the given value.
@@ -4496,7 +4529,6 @@ declare module 'vscode' {
 		 *
 		 * @param range The range the color appears in. Must not be empty.
 		 * @param color The value of the color.
-		 * @param format The format in which this color is currently formatted.
 		 */
 		constructor(range: Range, color: Color);
 	}
@@ -4654,18 +4686,28 @@ declare module 'vscode' {
 
 		/**
 		 * The tooltip text when you hover over this item.
+		 *
+		 * *Note* that this property can be set late during
+		 * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
 		 */
 		tooltip?: string | MarkdownString | undefined;
-
-		/**
-		 * Optional command that will be the default gesture of this inlay hint.
-		 */
-		command?: Command;
 
 		/**
 		 * The kind of this hint. The inlay hint kind defines the appearance of this inlay hint.
 		 */
 		kind?: InlayHintKind;
+
+		/**
+		 * Optional {@link TextEdit text edits} that are performed when accepting this inlay hint. The default
+		 * gesture for accepting an inlay hint is the double click.
+		 *
+		 * *Note* that edits are expected to change the document so that the inlay hint (or its nearest variant) is
+		 * now part of the document and the inlay hint itself is now obsolete.
+		 *
+		 * *Note* that this property can be set late during
+		 * {@link InlayHintsProvider.resolveInlayHint resolving} of inlay hints.
+		 */
+		textEdits?: TextEdit[];
 
 		/**
 		 * Render padding before the hint. Padding will use the editor's background color,
@@ -4715,8 +4757,8 @@ declare module 'vscode' {
 		provideInlayHints(document: TextDocument, range: Range, token: CancellationToken): ProviderResult<T[]>;
 
 		/**
-		 * Given an inlay hint fill in {@link InlayHint.tooltip tooltip}, {@link InlayHint.command command}, or complete
-		 * label {@link InlayHintLabelPart parts}.
+		 * Given an inlay hint fill in {@link InlayHint.tooltip tooltip}, {@link InlayHint.textEdits text edits},
+		 * or complete label {@link InlayHintLabelPart parts}.
 		 *
 		 * *Note* that the editor will resolve an inlay hint at most once.
 		 *
@@ -6496,8 +6538,8 @@ declare module 'vscode' {
 		extensionKind: ExtensionKind;
 
 		/**
-		 * The public API exported by this extension. It is an invalid action
-		 * to access this field before this extension has been activated.
+		 * The public API exported by this extension (return value of `activate`).
+		 * It is an invalid action to access this field before this extension has been activated.
 		 */
 		readonly exports: T;
 
@@ -6783,7 +6825,8 @@ declare module 'vscode' {
 	export enum ColorThemeKind {
 		Light = 1,
 		Dark = 2,
-		HighContrast = 3
+		HighContrast = 3,
+		HighContrastLight = 4
 	}
 
 	/**
@@ -6792,7 +6835,7 @@ declare module 'vscode' {
 	export interface ColorTheme {
 
 		/**
-		 * The kind of this color theme: light, dark or high contrast.
+		 * The kind of this color theme: light, dark, high contrast dark and high contrast light.
 		 */
 		readonly kind: ColorThemeKind;
 	}
@@ -7211,7 +7254,7 @@ declare module 'vscode' {
 		/**
 		 * Creates a new task.
 		 *
-		 * @param definition The task definition as defined in the taskDefinitions extension point.
+		 * @param taskDefinition The task definition as defined in the taskDefinitions extension point.
 		 * @param scope Specifies the task's scope. It is either a global or a workspace task or a task for a specific workspace folder. Global tasks are currently not supported.
 		 * @param name The task's name. Is presented in the user interface.
 		 * @param source The task's source (e.g. 'gulp', 'npm', ...). Is presented in the user interface.
@@ -7227,7 +7270,7 @@ declare module 'vscode' {
 		 *
 		 * @deprecated Use the new constructors that allow specifying a scope for the task.
 		 *
-		 * @param definition The task definition as defined in the taskDefinitions extension point.
+		 * @param taskDefinition The task definition as defined in the taskDefinitions extension point.
 		 * @param name The task's name. Is presented in the user interface.
 		 * @param source The task's source (e.g. 'gulp', 'npm', ...). Is presented in the user interface.
 		 * @param execution The process or shell execution.
@@ -7864,8 +7907,8 @@ declare module 'vscode' {
 		/**
 		 * Rename a file or folder.
 		 *
-		 * @param oldUri The existing file.
-		 * @param newUri The new location.
+		 * @param source The existing file.
+		 * @param target The new location.
 		 * @param options Defines if existing files should be overwritten.
 		 */
 		rename(source: Uri, target: Uri, options?: { overwrite?: boolean }): Thenable<void>;
@@ -7874,7 +7917,7 @@ declare module 'vscode' {
 		 * Copy files or folders.
 		 *
 		 * @param source The existing file.
-		 * @param destination The destination location.
+		 * @param target The destination location.
 		 * @param options Defines if existing files should be overwritten.
 		 */
 		copy(source: Uri, target: Uri, options?: { overwrite?: boolean }): Thenable<void>;
@@ -7924,7 +7967,7 @@ declare module 'vscode' {
 		/**
 		 * Controls whether forms are enabled in the webview content or not.
 		 *
-		 * Defaults to true if {@link WebViewOptions.enableScripts scripts are enabled}. Otherwise defaults to false.
+		 * Defaults to true if {@link WebviewOptions.enableScripts scripts are enabled}. Otherwise defaults to false.
 		 * Explicitly setting this property to either true or false overrides the default.
 		 */
 		readonly enableForms?: boolean;
@@ -9360,11 +9403,16 @@ declare module 'vscode' {
 		export function createInputBox(): InputBox;
 
 		/**
-		 * Creates a new {@link OutputChannel output channel} with the given name.
+		 * Creates a new {@link OutputChannel output channel} with the given name and language id
+		 * If language id is not provided, then **Log** is used as default language id.
+		 *
+		 * You can access the visible or active output channel as a {@link TextDocument text document} from {@link window.visibleTextEditors visible editors} or {@link window.activeTextEditor active editor}
+		 * and use the langage id to contribute language features like syntax coloring, code lens etc.,
 		 *
 		 * @param name Human-readable string which will be used to represent the channel in the UI.
+		 * @param languageId The identifier of the language associated with the channel.
 		 */
-		export function createOutputChannel(name: string): OutputChannel;
+		export function createOutputChannel(name: string, languageId?: string): OutputChannel;
 
 		/**
 		 * Create and show a new webview panel.
@@ -9674,6 +9722,11 @@ declare module 'vscode' {
 		 * array containing all selected tree items.
 		 */
 		canSelectMany?: boolean;
+
+		/**
+		* An optional interface to implement drag and drop in the tree view.
+		*/
+		dragAndDropController?: TreeDragAndDropController<T>;
 	}
 
 	/**
@@ -9710,6 +9763,111 @@ declare module 'vscode' {
 		 */
 		readonly visible: boolean;
 
+	}
+
+	/**
+	 * A class for encapsulating data transferred during a drag and drop event.
+	 *
+	 * You can use the `value` of the `DataTransferItem` to get back the object you put into it
+	 * so long as the extension that created the `DataTransferItem` runs in the same extension host.
+	 */
+	export class DataTransferItem {
+		asString(): Thenable<string>;
+		readonly value: any;
+		constructor(value: any);
+	}
+
+	/**
+	 * A map containing a mapping of the mime type of the corresponding transferred data.
+	 *
+	 * Drag and drop controllers that implement {@link TreeDragAndDropController.handleDrag `handleDrag`} can add additional mime types to the
+	 * data transfer. These additional mime types will only be included in the `handleDrop` when the the drag was initiated from
+	 * an element in the same drag and drop controller.
+	 */
+	export class DataTransfer {
+		/**
+		 * Retrieves the data transfer item for a given mime type.
+		 *
+		 * @param mimeType The mime type to get the data transfer item for, such as `text/plain` or `image/png`.
+		 *
+		 * Special mime types:
+		 * - `text/uri-list` — A string with `toString()`ed Uris separated by newlines. To specify a cursor position in the file,
+		 * set the Uri's fragment to `L3,5`, where 3 is the line number and 5 is the column number.
+		 */
+		get(mimeType: string): DataTransferItem | undefined;
+
+		/**
+		 * Sets a mime type to data transfer item mapping.
+		 * @param mimeType The mime type to set the data for.
+		 * @param value The data transfer item for the given mime type.
+		 */
+		set(mimeType: string, value: DataTransferItem): void;
+
+		/**
+		 * Allows iteration through the data transfer items.
+		 * @param callbackfn Callback for iteration through the data transfer items.
+		 */
+		forEach(callbackfn: (value: DataTransferItem, key: string) => void): void;
+	}
+
+	/**
+	 * Provides support for drag and drop in `TreeView`.
+	 */
+	export interface TreeDragAndDropController<T> {
+
+		/**
+		 * The mime types that the {@link TreeDragAndDropController.handleDrop `handleDrop`} method of this `DragAndDropController` supports.
+		 * This could be well-defined, existing, mime types, and also mime types defined by the extension.
+		 *
+		 * To support drops from trees, you will need to add the mime type of that tree.
+		 * This includes drops from within the same tree.
+		 * The mime type of a tree is recommended to be of the format `application/vnd.code.tree.<treeidlowercase>`.
+		 *
+		 * To learn the mime type of a dragged item:
+		 * 1. Set up your `DragAndDropController`
+		 * 2. Use the Developer: Set Log Level... command to set the level to "Debug"
+		 * 3. Open the developer tools and drag the item with unknown mime type over your tree. The mime types will be logged to the developer console
+		 *
+		 * Note that mime types that cannot be sent to the extension will be omitted.
+		 */
+		readonly dropMimeTypes: string[];
+
+		/**
+		 * The mime types that the {@link TreeDragAndDropController.handleDrag `handleDrag`} method of this `TreeDragAndDropController` may add to the tree data transfer.
+		 * This could be well-defined, existing, mime types, and also mime types defined by the extension.
+		 *
+		 * The recommended mime type of the tree (`application/vnd.code.tree.<treeidlowercase>`) will be automatically added.
+		 */
+		readonly dragMimeTypes: string[];
+
+		/**
+		 * When the user starts dragging items from this `DragAndDropController`, `handleDrag` will be called.
+		 * Extensions can use `handleDrag` to add their {@link DataTransferItem `DataTransferItem`} items to the drag and drop.
+		 *
+		 * When the items are dropped on **another tree item** in **the same tree**, your `DataTransferItem` objects
+		 * will be preserved. Use the recommended mime type for the tree (`application/vnd.code.tree.<treeidlowercase>`) to add
+		 * tree objects in a data transfer. See the documentation for `DataTransferItem` for how best to take advantage of this.
+		 *
+		 * To add a data transfer item that can be dragged into the editor, use the application specific mime type "text/uri-list".
+		 * The data for "text/uri-list" should be a string with `toString()`ed Uris separated by newlines. To specify a cursor position in the file,
+		 * set the Uri's fragment to `L3,5`, where 3 is the line number and 5 is the column number.
+		 *
+		 * @param source The source items for the drag and drop operation.
+		 * @param dataTransfer The data transfer associated with this drag.
+		 * @param token A cancellation token indicating that drag has been cancelled.
+		 */
+		handleDrag?(source: T[], dataTransfer: DataTransfer, token: CancellationToken): Thenable<void> | void;
+
+		/**
+		 * Called when a drag and drop action results in a drop on the tree that this `DragAndDropController` belongs to.
+		 *
+		 * Extensions should fire {@link TreeDataProvider.onDidChangeTreeData onDidChangeTreeData} for any elements that need to be refreshed.
+		 *
+		 * @param dataTransfer The data transfer items of the source of the drag.
+		 * @param target The target tree element that the drop is occurring on. When undefined, the target is the root.
+		 * @param token A cancellation token indicating that the drop has been cancelled.
+		 */
+		handleDrop?(target: T | undefined, dataTransfer: DataTransfer, token: CancellationToken): Thenable<void> | void;
 	}
 
 	/**
@@ -9789,7 +9947,7 @@ declare module 'vscode' {
 		 * This will trigger the view to update the changed element/root and its children recursively (if shown).
 		 * To signal that root has changed, do not pass any argument or pass `undefined` or `null`.
 		 */
-		onDidChangeTreeData?: Event<T | undefined | null | void>;
+		onDidChangeTreeData?: Event<T | T[] | undefined | null | void>;
 
 		/**
 		 * Get {@link TreeItem} representation of the `element`
@@ -10395,17 +10553,20 @@ declare module 'vscode' {
 
 		/**
 		 * Show progress for the source control viewlet, as overlay for the icon and as progress bar
-		 * inside the viewlet (when visible). Neither supports cancellation nor discrete progress.
+		 * inside the viewlet (when visible). Neither supports cancellation nor discrete progress nor
+		 * a label to describe the operation.
 		 */
 		SourceControl = 1,
 
 		/**
 		 * Show progress in the status bar of the editor. Neither supports cancellation nor discrete progress.
+		 * Supports rendering of {@link ThemeIcon theme icons} via the `$(<name>)`-syntax in the progress label.
 		 */
 		Window = 10,
 
 		/**
-		 * Show progress as notification with an optional cancel button. Supports to show infinite and discrete progress.
+		 * Show progress as notification with an optional cancel button. Supports to show infinite and discrete
+		 * progress but does not support rendering of icons.
 		 */
 		Notification = 15
 	}
@@ -11770,10 +11931,10 @@ declare module 'vscode' {
 		 * 1. When {@linkcode DocumentSelector} is an array, compute the match for each contained `DocumentFilter` or language identifier and take the maximum value.
 		 * 2. A string will be desugared to become the `language`-part of a {@linkcode DocumentFilter}, so `"fooLang"` is like `{ language: "fooLang" }`.
 		 * 3. A {@linkcode DocumentFilter} will be matched against the document by comparing its parts with the document. The following rules apply:
-		 *  1. When the `DocumentFilter` is empty (`{}`) the result is `0`
-		 *  2. When `scheme`, `language`, or `pattern` are defined but one doesn't match, the result is `0`
-		 *  3. Matching against `*` gives a score of `5`, matching via equality or via a glob-pattern gives a score of `10`
-		 *  4. The result is the maximum value of each match
+		 *    1. When the `DocumentFilter` is empty (`{}`) the result is `0`
+		 *    2. When `scheme`, `language`, `pattern`, or `notebook` are defined but one doesn't match, the result is `0`
+		 *    3. Matching against `*` gives a score of `5`, matching via equality or via a glob-pattern gives a score of `10`
+		 *    4. The result is the maximum value of each match
 		 *
 		 * Samples:
 		 * ```js
@@ -11781,8 +11942,8 @@ declare module 'vscode' {
 		 * doc.uri; //'file:///my/file.js'
 		 * doc.languageId; // 'javascript'
 		 * match('javascript', doc); // 10;
-		 * match({language: 'javascript'}, doc); // 10;
-		 * match({language: 'javascript', scheme: 'file'}, doc); // 10;
+		 * match({ language: 'javascript' }, doc); // 10;
+		 * match({ language: 'javascript', scheme: 'file' }, doc); // 10;
 		 * match('*', doc); // 5
 		 * match('fooLang', doc); // 0
 		 * match(['fooLang', '*'], doc); // 5
@@ -11791,8 +11952,16 @@ declare module 'vscode' {
 		 * doc.uri; // 'git:/my/file.js'
 		 * doc.languageId; // 'javascript'
 		 * match('javascript', doc); // 10;
-		 * match({language: 'javascript', scheme: 'git'}, doc); // 10;
+		 * match({ language: 'javascript', scheme: 'git' }, doc); // 10;
 		 * match('*', doc); // 5
+		 *
+		 * // notebook cell document
+		 * doc.uri; // `vscode-notebook-cell:///my/notebook.ipynb#gl65s2pmha`;
+		 * doc.languageId; // 'python'
+		 * match({ notebookType: 'jupyter-notebook' }, doc) // 10
+		 * match({ notebookType: 'fooNotebook', language: 'python' }, doc) // 0
+		 * match({ language: 'python' }, doc) // 10
+		 * match({ notebookType: '*' }, doc) // 5
 		 * ```
 		 *
 		 * @param selector A document selector.
@@ -13929,7 +14098,7 @@ declare module 'vscode' {
 		 * Registering a single provider with resolve methods for different trigger kinds, results in the same resolve methods called multiple times.
 		 * More than one provider can be registered for the same type.
 		 *
-		 * @param type The debug type for which the provider is registered.
+		 * @param debugType The debug type for which the provider is registered.
 		 * @param provider The {@link DebugConfigurationProvider debug configuration provider} to register.
 		 * @param triggerKind The {@link DebugConfigurationProviderTrigger trigger} for which the 'provideDebugConfiguration' method of the provider is registered. If `triggerKind` is missing, the value `DebugConfigurationProviderTriggerKind.Initial` is assumed.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
@@ -14801,7 +14970,7 @@ declare module 'vscode' {
 		 * removed tests.
 		 *
 		 * It's recommended that extensions try to update tests in realtime, using
-		 * a {@link FileWatcher} for example, and use this method as a fallback.
+		 * a {@link FileSystemWatcher} for example, and use this method as a fallback.
 		 *
 		 * @returns A thenable that resolves when tests have been refreshed.
 		 */
@@ -14888,7 +15057,7 @@ declare module 'vscode' {
 		readonly profile: TestRunProfile | undefined;
 
 		/**
-		 * @param tests Array of specific tests to run, or undefined to run all tests
+		 * @param include Array of specific tests to run, or undefined to run all tests
 		 * @param exclude An array of tests to exclude from the run.
 		 * @param profile The run profile used for this request.
 		 */
@@ -14939,7 +15108,7 @@ declare module 'vscode' {
 		 * Indicates a test has failed. You should pass one or more
 		 * {@link TestMessage TestMessages} to describe the failure.
 		 * @param test Test item to update.
-		 * @param messages Messages associated with the test failure.
+		 * @param message Messages associated with the test failure.
 		 * @param duration How long the test took to execute, in milliseconds.
 		 */
 		failed(test: TestItem, message: TestMessage | readonly TestMessage[], duration?: number): void;
@@ -14950,7 +15119,7 @@ declare module 'vscode' {
 		 * from the "failed" state in that it indicates a test that couldn't be
 		 * executed at all, from a compilation error for example.
 		 * @param test Test item to update.
-		 * @param messages Messages associated with the test failure.
+		 * @param message Messages associated with the test failure.
 		 * @param duration How long the test took to execute, in milliseconds.
 		 */
 		errored(test: TestItem, message: TestMessage | readonly TestMessage[], duration?: number): void;
@@ -15008,7 +15177,7 @@ declare module 'vscode' {
 		/**
 		 * Adds the test item to the children. If an item with the same ID already
 		 * exists, it'll be replaced.
-		 * @param items Item to add.
+		 * @param item Item to add.
 		 */
 		add(item: TestItem): void;
 


### PR DESCRIPTION
Please consider the following changes:

[Change separator between hint and argument to = for python](https://github.com/RobertOstermann/vscode-inline-parameters/commit/6d28326f7f6a6c38607c5c66507e3f73f027e55e)
Changes the separator from ':' to '=' to match pythons syntax.

[Fix hints for calls of class constructor in python](https://github.com/RobertOstermann/vscode-inline-parameters/commit/df7e64ed3cce54bc64847ebf134553a707156668)
Fixes the regex for extracting constructor signature from expecting '(class)' to 'class' to work with Pylance v2023.3.20.
Additionally, the extraction of the parameters is simplified by making use of the capturing groups of the regex.

[Update VS Code API and minimum version to 1.66.0](https://github.com/RobertOstermann/vscode-inline-parameters/commit/86ee154aed303bb10d71d6bb65871f54e82ce9b3)
Updates vscode.d.ts in preparation for the next commit.

[Add support for insertion of inlay hint label on double-click for python](https://github.com/RobertOstermann/vscode-inline-parameters/commit/8b8df43d5a79610604f4894e47740d05a3e7bce7)
Adds support for inserting inlay hint labels into the source code by double-click. This matches the functionality already available in VS Code for type hints into the code.
The insertion turns a positional argument into a keyword argument. As python does allow positional argument after keyword arguments, only the last positional argument can be turned into a keyword argument at a time. So in order to turn all arguments of a call, the corresponding inlay hints have to be clicked from right to left.
