### PR TITLE
Fix incorrect inline parameter names when complex type hinting is used

### DIFF
--- a/src/python/pythonHelper.ts
+++ b/src/python/pythonHelper.ts
@@ -157,20 +157,18 @@ export default class PythonHelper {
         console.error(error);
       }
     }
-
-    const pythonParameterNameRegex = /^[a-zA-Z_]([0-9a-zA-Z_]+)?/g;
-    const parameters: string[] = definition
+    
+    const pythonParameterRegex = /\*?[a-zA-Z_][0-9a-zA-Z_]+?:/g;
+    const parameters: string[] = Array.from(definition.match(pythonParameterRegex), m => m)
       // eslint-disable-next-line no-useless-escape
-      .split(/,/)
-      .map(parameter => parameter.trim())
       .map(parameter => {
-        const matches = parameter.replace(/\*/g, "").match(pythonParameterNameRegex);
-        if (!matches || !matches[0] || isVariadic) {
+        const paramaterName = parameter.replace(/\*|:/g, "");
+        if (isVariadic) {
           return null;
         }
         if (parameter.includes("*")) isVariadic = true;
 
-        return matches[0];
+        return paramaterName;
       })
       .filter(parameter => parameter);
 


### PR DESCRIPTION
Hi :)
Thanks for the great project!

I noticed that inline parameteres for python don't work as intended when complex type hinting is used (see picture.)
![2023-09-11_11-16-39](https://github.com/RobertOstermann/vscode-inline-parameters/assets/58849671/1fd33050-ae19-4234-8ac0-2d9ee2bf34c5)

This PR hopefully fixes that.
I tested the code logic locally and it works on [various test examples](https://regex101.com/r/80aug3/1) that I came up with.
I don't know how to set it up to run it in VS Code.

This is the code i used to test the new logic locally:
```js
const definition = `
    first: str,
    second: str | Tuple[int, int, float, float, float],
    third: Unknown,
    fourth: dict[Unknown, Unknown],
    *fifth: Unknown,
    sixth: Unknown | None = None`

let isVariadic = false;
const pythonParameterRegex = /(\*?[a-zA-Z_][0-9a-zA-Z_]+?):/g;
const parameters = Array.from(definition.match(pythonParameterRegex), m => m)
      // eslint-disable-next-line no-useless-escape
      .map(parameter => {
        const paramaterName = parameter.replace(/\*|:/g, "");
        if (isVariadic) {
          return null;
        }
        if (parameter.includes("*")) isVariadic = true;

        return paramaterName;
      })
      .filter(parameter => parameter);

console.log(parameters)
```

Let me know if you think any additional changes are needed.